### PR TITLE
feat: add new config `config.getCommonStyle` `config.getCompUnitless` for `genStyleUtils`

### DIFF
--- a/docs/demos/genStyleUtils.md
+++ b/docs/demos/genStyleUtils.md
@@ -10,11 +10,13 @@ nav:
 
 ## 入参介绍
 
-### `genStyleUtils<CompTokenMap>(getConfigProviderContext?, getThemeProviderContext?)`
+### `genStyleUtils<CompTokenMap, AliasToken, DesignToken>(config)`
 - `config`: 可选，配置
   - `useCSP`: 使用 CSP 的钩子函数
   - `usePrefix`: 使用样式前缀的钩子函数
   - `useToken`: 使用 token 的钩子函数
+  - `getResetStyles`: 获取重置样式函数
+  - `getCommonStyle`: 获取通用样式函数
 - `CompTokenMap`: 范型参数，表示组件 token 映射
 - `AliasToken`: 范型参数，表示别名 token
 - `DesignToken`: 范型参数，表示设计 token

--- a/docs/demos/genStyleUtils.md
+++ b/docs/demos/genStyleUtils.md
@@ -17,6 +17,7 @@ nav:
   - `useToken`: 使用 token 的钩子函数
   - `getResetStyles`: 获取重置样式函数
   - `getCommonStyle`: 获取通用样式函数
+  - `getCompUnitless`: 获取组件无单位样式函数
 - `CompTokenMap`: 范型参数，表示组件 token 映射
 - `AliasToken`: 范型参数，表示别名 token
 - `DesignToken`: 范型参数，表示设计 token

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { default as genCalc } from './util/calc';
 export {
   default as statisticToken,
   merge as mergeToken,
+  statistic,
 } from './util/statistic';
 
 export type {

--- a/src/util/genStyleUtils.tsx
+++ b/src/util/genStyleUtils.tsx
@@ -378,8 +378,7 @@ export default function genStyleUtils<
       const { max, min } = genMaxMin(type);
 
       // Shared config
-      const sharedConfig: Omit<Parameters<typeof useStyleRegister>[0], 'path'> =
-      {
+      const sharedConfig: Omit<Parameters<typeof useStyleRegister>[0], 'path'> = {
         theme,
         token,
         hashId,
@@ -396,7 +395,7 @@ export default function genStyleUtils<
       // Generate style for all need reset tags.
       useStyleRegister(
         { ...sharedConfig, clientOnly: false, path: ['Shared', rootPrefixCls] },
-        () => getResetStyles?.(token) ?? [],
+        () => typeof getResetStyles === 'function' ? getResetStyles(token) : [],
       );
 
       const wrapSSR = useStyleRegister(
@@ -412,7 +411,7 @@ export default function genStyleUtils<
             CompTokenMap,
             AliasToken,
             C
-          >(component, realToken, getDefaultToken) ?? {};
+          >(component, realToken, getDefaultToken);
 
           const componentCls = `.${prefixCls}`;
           const componentToken = getComponentToken<CompTokenMap, AliasToken, C>(
@@ -437,8 +436,8 @@ export default function genStyleUtils<
             {
               componentCls,
               prefixCls,
-              iconCls: !!iconPrefixCls.length ? '' : `.${iconPrefixCls}`,
-              antCls: !!rootPrefixCls.length ? '' : `.${rootPrefixCls}`,
+              iconCls: `.${iconPrefixCls}`,
+              antCls: `.${rootPrefixCls}`,
               calc,
               // @ts-ignore
               max,
@@ -455,15 +454,18 @@ export default function genStyleUtils<
             iconPrefixCls,
           });
           flush(component, componentToken);
-          return [
-            options.resetStyle === false
-              ? null
-              : getCommonStyle?.(
+          const commonStyle = typeof getCommonStyle === 'function'
+            ? getCommonStyle(
                 mergedToken,
                 prefixCls,
                 rootCls,
-                options.resetFont,
-              ) ?? {},
+                options.resetFont
+              )
+            : null;
+          return [
+            options.resetStyle === false
+              ? null
+              : commonStyle,
             styleInterpolation,
           ];
         },

--- a/src/util/genStyleUtils.tsx
+++ b/src/util/genStyleUtils.tsx
@@ -422,7 +422,7 @@ export default function genStyleUtils<
             },
           );
 
-          if (cssVar) {
+          if (cssVar && typeof defaultComponentToken === 'object') {
             Object.keys(defaultComponentToken).forEach((key) => {
               defaultComponentToken[key] = `var(${token2CSSVar(
                 key,

--- a/src/util/genStyleUtils.tsx
+++ b/src/util/genStyleUtils.tsx
@@ -112,6 +112,12 @@ export default function genStyleUtils<
     useToken: UseToken<CompTokenMap, AliasToken, DesignToken>;
     useCSP?: UseCSP;
     getResetStyles?: GetResetStyles<CompTokenMap, AliasToken>,
+    getCommonStyle?: (
+      token: OverrideTokenMap<CompTokenMap, AliasToken>,
+      componentPrefixCls: string,
+      rootCls?: string,
+      resetFont?: boolean,
+    ) => CSSObject;
   }
 ) {
   // Dependency inversion for preparing basic config.
@@ -120,6 +126,7 @@ export default function genStyleUtils<
     useToken,
     usePrefix,
     getResetStyles,
+    getCommonStyle,
   } = config;
 
   function genStyleHooks<C extends TokenMapKey<CompTokenMap>>(
@@ -166,7 +173,20 @@ export default function genStyleUtils<
     // Fill unitless
     const originUnitless = options?.unitless || {};
     const compUnitless: any = {
-      ...originUnitless,
+      // Todo: ...unitless,
+      // ...originUnitless,
+      lineHeight: true,
+      lineHeightSM: true,
+      lineHeightLG: true,
+      lineHeightHeading1: true,
+      lineHeightHeading2: true,
+      lineHeightHeading3: true,
+      lineHeightHeading4: true,
+      lineHeightHeading5: true,
+      opacityLoading: true,
+      fontWeightStrong: true,
+      zIndexPopupBase: true,
+      zIndexBase: true,
       [prefixToken('zIndexPopup')]: true,
     };
     Object.keys(originUnitless).forEach((key) => {
@@ -315,12 +335,6 @@ export default function genStyleUtils<
       unitless?: {
         [key in ComponentTokenKey<CompTokenMap, AliasToken, C>]: boolean;
       };
-      genCommonStyle?: (
-        token: OverrideTokenMap<CompTokenMap, AliasToken>,
-        componentPrefixCls: string,
-        rootCls?: string,
-        resetFont?: boolean,
-      ) => CSSObject;
     } = {},
   ) {
     const cells = (
@@ -444,7 +458,7 @@ export default function genStyleUtils<
           return [
             options.resetStyle === false
               ? null
-              : options?.genCommonStyle?.(
+              : getCommonStyle?.(
                 mergedToken,
                 prefixCls,
                 rootCls,

--- a/src/util/statistic.ts
+++ b/src/util/statistic.ts
@@ -21,6 +21,8 @@ export function merge<CompTokenMap extends TokenMap>(...objs: Partial<CompTokenM
   const ret = {} as CompTokenMap;
 
   objs.forEach((obj) => {
+    if (typeof obj !== 'object') return;
+
     const keys = Object.keys(obj);
 
     keys.forEach((key) => {


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 工作流程
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
无

### 💡 需求背景和解决方案
#### `genStyleUtils` 新增属性
在用 `@ant-design/cssinjs-utils` 重构 `antd` 的过程中，发现的问题：

`genCommonStyle` 函数被 `genComponentStyleHook` 使用，`@ant-design/cssinjs-utils@1.0.0` 版本将其扩展为 `genComponentStyleHook` 函数的 `options.genCommonStyle` 属性。这会导致一些问题：
 - 每次使用 `genComponentStyleHook` 都需要将 `options.genCommonStyle` 传入
 - 需进行封装，但在每个组件生成 `useStyle` 时会多一次函数调用

另外考虑参数命名的一致性，将 `genCommonStyle` 更名为 `getCommonStyle`。

原 `unitless` 常量被 `genStyleHooks` 中使用，考虑通用性，将其抽象为 `config.getCompUnitless`。
#### 修复
修复了 `genComponentStyleHook` 内部的逻辑问题，该问题会导致基础样式异常。

### 📝 更新日志


| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |     add new config `config.getCommonStyle` `config.getCompUnitless` for `genStyleUtils`     |
| 🇨🇳 中文 |    `genStyleUtils` 新增配置属性 `config.getCommonStyle`  `config.getCompUnitless`    |