### PR TITLE
chore: improve TS definition syntax

### DIFF
--- a/src/util/genStyleUtils.tsx
+++ b/src/util/genStyleUtils.tsx
@@ -97,9 +97,7 @@ export type GetCompUnitless<CompTokenMap extends TokenMap, AliasToken extends To
   C extends TokenMapKey<CompTokenMap>,
 >(
   component: C | [C, string],
-) => {
-  [key in ComponentTokenKey<CompTokenMap, AliasToken, C>]: boolean;
-};
+) => Partial<Record<ComponentTokenKey<CompTokenMap, AliasToken, C>, boolean>>;
 
 function genStyleUtils<
   CompTokenMap extends TokenMap,
@@ -143,9 +141,7 @@ function genStyleUtils<
       /**
        * Component tokens that do not need unit.
        */
-      unitless?: {
-        [key in ComponentTokenKey<CompTokenMap, AliasToken, C>]: boolean;
-      };
+      unitless?: Partial<Record<ComponentTokenKey<CompTokenMap, AliasToken, C>, boolean>>;
       /**
        * Only use component style in client side. Ignore in SSR.
        */
@@ -207,12 +203,8 @@ function genStyleUtils<
     component: C,
     getDefaultToken: GetDefaultToken<CompTokenMap, AliasToken, C> | undefined,
     options: {
-      unitless?: {
-        [key in ComponentTokenKey<CompTokenMap, AliasToken, C>]: boolean;
-      };
-      ignore?: {
-        [key in keyof AliasToken]?: boolean;
-      };
+      unitless?: Partial<Record<ComponentTokenKey<CompTokenMap, AliasToken, C>, boolean>>;
+      ignore?: Partial<Record<keyof AliasToken, boolean>>
       deprecatedTokens?: [
         ComponentTokenKey<CompTokenMap, AliasToken, C>,
         ComponentTokenKey<CompTokenMap, AliasToken, C>,
@@ -300,9 +292,7 @@ function genStyleUtils<
        */
       order?: number;
       injectStyle?: boolean;
-      unitless?: {
-        [key in ComponentTokenKey<CompTokenMap, AliasToken, C>]: boolean;
-      };
+      unitless?: Partial<Record<ComponentTokenKey<CompTokenMap, AliasToken, C>, boolean>>;
     } = {},
   ) {
     const cells = (
@@ -448,9 +438,7 @@ function genStyleUtils<
        */
       order?: number;
       injectStyle?: boolean;
-      unitless?: {
-        [key in ComponentTokenKey<CompTokenMap, AliasToken, C>]: boolean;
-      };
+      unitless?: Partial<Record<ComponentTokenKey<CompTokenMap, AliasToken, C>, boolean>>;
     } = {},
   ) {
     const useStyle = genComponentStyleHook(componentName, styleFn, getDefaultToken, {


### PR DESCRIPTION
试图解决：https://github.com/ant-design/ant-design/issues/51171

### 问题过程：

发现 antd 的构建产物是有问题的：ref: https://npmmirror.com/package/antd/files/es/theme/util/genStyleUtils.d.ts?version=5.21.3#L6 
<img width="1649" alt="image" src="https://github.com/user-attachments/assets/8befa808-14f2-43ca-a55d-1445e7e5820f">

追踪构建产物，发现是 cssinjs-utils 的构建产物长这样：https://npmmirror.com/package/@ant-design/cssinjs-utils/files/es/util/genStyleUtils.d.ts?version=1.1.0#L67-L68

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/5fb20d25-7b90-4733-9509-965ff915de94">


上面这个 cssinjs-utils 的构建产物很奇怪，不缺定是不是 tsc 的问题还是 father 构建的问题。 @PeachScript 大佬有空可以帮忙看看，

### 解决方案

改用 `Partial<Record<>>` 代替 `{ [key in xxx]: xxx }`. 方案。

最后  cssinjs-utils 的构建产物长这样：
<img width="1592" alt="image" src="https://github.com/user-attachments/assets/0d6f8c49-260b-47fc-ac13-b0dd9efea5fe">

能解决 antd 侧构建出来的内容缺少类型定义


