### PR TITLE
refactor: add config for getResetStyles

### DIFF
--- a/src/util/genStyleUtils.tsx
+++ b/src/util/genStyleUtils.tsx
@@ -350,8 +350,9 @@ function genStyleUtils<
         order: options.order || -999,
       };
 
-      // Generate style for all need reset tags.
+      // This if statement is safe, as it will only be used if the generator has the function. It's not dynamic.
       if (typeof getResetStyles === 'function') {
+        // Generate style for all need reset tags.
         useStyleRegister(
           { ...sharedConfig, clientOnly: false, path: ['Shared', rootPrefixCls] },
           () => getResetStyles(token, { prefix: { rootPrefixCls, iconPrefixCls }, csp }),

--- a/src/util/genStyleUtils.tsx
+++ b/src/util/genStyleUtils.tsx
@@ -91,7 +91,12 @@ export type CSSVarRegisterProps = {
   };
 };
 
-export type GetResetStyles<AliasToken extends TokenType> = (token: AliasToken) => CSSInterpolation;
+type GetResetStylesConfig = {
+  prefix: ReturnType<UsePrefix>;
+  csp: ReturnType<UseCSP>
+};
+
+export type GetResetStyles<AliasToken extends TokenType> = (token: AliasToken, config?: GetResetStylesConfig) => CSSInterpolation;
 
 export type GetCompUnitless<CompTokenMap extends TokenMap, AliasToken extends TokenType> = <
   C extends TokenMapKey<CompTokenMap>,
@@ -348,7 +353,14 @@ function genStyleUtils<
       // Generate style for all need reset tags.
       useStyleRegister(
         { ...sharedConfig, clientOnly: false, path: ['Shared', rootPrefixCls] },
-        () => (typeof getResetStyles === 'function' ? getResetStyles(token) : []),
+        () => (
+          typeof getResetStyles === 'function'
+            ? getResetStyles(token, {
+                prefix: { rootPrefixCls, iconPrefixCls },
+                csp,
+              })
+            : []
+        ),
       );
 
       const wrapSSR = useStyleRegister(

--- a/src/util/genStyleUtils.tsx
+++ b/src/util/genStyleUtils.tsx
@@ -351,17 +351,12 @@ function genStyleUtils<
       };
 
       // Generate style for all need reset tags.
-      useStyleRegister(
-        { ...sharedConfig, clientOnly: false, path: ['Shared', rootPrefixCls] },
-        () => (
-          typeof getResetStyles === 'function'
-            ? getResetStyles(token, {
-                prefix: { rootPrefixCls, iconPrefixCls },
-                csp,
-              })
-            : []
-        ),
-      );
+      if (typeof getResetStyles === 'function') {
+        useStyleRegister(
+          { ...sharedConfig, clientOnly: false, path: ['Shared', rootPrefixCls] },
+          () => getResetStyles(token, { prefix: { rootPrefixCls, iconPrefixCls }, csp }),
+        );
+      }
 
       const wrapSSR = useStyleRegister(
         { ...sharedConfig, path: [concatComponent, prefixCls, iconPrefixCls] },

--- a/tests/genStyleUtils.test.tsx
+++ b/tests/genStyleUtils.test.tsx
@@ -88,6 +88,27 @@ describe('genStyleUtils', () => {
     });
   });
 
+  describe('genComponentStyleHook should run without getResetStyles', () => {
+    it('should generate component style hook', () => {
+      const component = 'TestComponent';
+      const styleFn = jest.fn();
+      const getDefaultToken = jest.fn();
+      const { getResetStyles, ...restMockConfig } = mockConfig;
+      const { genComponentStyleHook: genComponentStyleHookWithoutReset } = genStyleUtils<
+        TestCompTokenMap,
+        object,
+        object
+      >(restMockConfig);
+      const hook = genComponentStyleHookWithoutReset(component, styleFn, getDefaultToken);
+      const TestComponent: React.FC<SubStyleComponentProps> = ({ prefixCls, rootCls }) => {
+        hook(prefixCls, rootCls);
+        return <div data-testid="test-component">Test</div>;
+      };
+      const { container } = render(<TestComponent prefixCls="test-prefix" rootCls="test-root" />);
+      expect(() => container).not.toThrow();
+    });
+  });
+
   describe('CSSVarRegister', () => {
     it('should render CSSVarRegister component', () => {
       const CSSVarRegister: React.FC<CSSVarRegisterProps> = ({ rootCls, cssVar = {} }) => {


### PR DESCRIPTION
https://github.com/ant-design/ant-design/issues/51457#issuecomment-2517615068

上述 issues 里描述了 icon 样式被重复创建的问题，计划将 useResetIconStyle 整合至 getResetStyles


该 PR 发布后，对 antd 仓库的 [genStyleUtils.ts](https://github.com/ant-design/ant-design/blob/3f8943e2744f41f6c1434225b8f72d2813b1b722/components/theme/util/genStyleUtils.ts#L34) 进行如下修改：
```tsx
export const { genStyleHooks, genComponentStyleHook, genSubStyleComponent } = genStyleUtils<
  ComponentTokenMap,
  AliasToken,
  SeedToken
>({
  // ... other config
  useCSP: () => {
    const { csp, iconPrefixCls } = useContext(ConfigContext);

    // before
    // - useResetIconStyle(iconPrefixCls, csp);
    return csp ?? {};
  },
  // now
  getResetStyles: (token, info) => [{ '&': genLinkStyle(token), [info.prefix.iconPrefixCls]: genIconStyle() }],
});

```